### PR TITLE
feat: add catalog MFE settings to openedx-lms-production-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ See the fragment files in the [changelog.d/ directory](./changelog.d).
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.1.0'></a>
+## 21.1.0 — 2026-04-27
+
+### Added
+
+- Support for the frontend-app-catalog MFE (`CATALOG_MICROFRONTEND_URL` and `ENABLE_CATALOG_MICROFRONTEND` settings).
+
 <a id='changelog-21.0.0'></a>
 ## 21.0.0 — 2026-01-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tutor-contrib-mfe-extensions"
-version = "21.0.0"
+version = "21.1.0"
 description = "mfe_extensions plugin for Tutor"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tutormfe_extensions/patches/openedx-lms-production-settings
+++ b/tutormfe_extensions/patches/openedx-lms-production-settings
@@ -42,6 +42,11 @@ COMMUNICATIONS_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% e
 MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ LMS_HOST }}/authoring"
 {% endif %}
 
+{% if get_mfe("catalog") %}
+CATALOG_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/catalog"
+ENABLE_CATALOG_MICROFRONTEND = True
+{% endif %}
+
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ CMS_HOST }}")
 {% endif %}
 STATIC_URL = "{{ MFE_EXTENSIONS_CDN_URL }}/static/"


### PR DESCRIPTION
### Description

This PR adds support for the `frontend-app-catalog` MFE by including the necessary LMS settings when the MFE is enabled.