### PR TITLE
feat: add support for the admin-console MFE

### DIFF
--- a/changelog.d/20260513_172545_moises.gonzalez_add_admin_console.md
+++ b/changelog.d/20260513_172545_moises.gonzalez_add_admin_console.md
@@ -1,0 +1,4 @@
+### Added
+
+- Add support for the Admin Console MFE that was added to the Core MFEs in Ulmo.
+

--- a/tutormfe_extensions/patches/openedx-lms-production-settings
+++ b/tutormfe_extensions/patches/openedx-lms-production-settings
@@ -2,6 +2,11 @@
 LEARNING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/learning"
 MFE_CONFIG["LEARNING_BASE_URL"] = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/learning"
 
+% if get_mfe("admin-console") %}
+ADMIN_CONSOLE_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ LMS_HOST }}/admin-console"
+MFE_CONFIG["ADMIN_CONSOLE_URL"] = ADMIN_CONSOLE_MICROFRONTEND_URL
+{% endif %}
+
 {%- if get_mfe("authn") %}
 AUTHN_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/authn"
 AUTHN_MICROFRONTEND_DOMAIN  = "{{ LMS_HOST }}/authn"


### PR DESCRIPTION
The admin console was added to Ulmo in this PR: https://github.com/overhangio/tutor-mfe/pull/276