### PR TITLE
fix: properly load enabled MFE lists from settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ See the fragment files in the [changelog.d/ directory](./changelog.d).
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-21.0.1'></a>
+## 21.0.1 — 2026-05-14
+
+### Added
+
+- Add support for the Admin Console MFE that was added to the Core MFEs in Ulmo.
+
+### Fixed
+
+- MFEs added or removed using the `MFE_*_MFE_APP` setting are now properly
+  rendered by the templates in tutor-mfe.
+
 <a id='changelog-21.0.0'></a>
 ## 21.0.0 — 2026-01-29
 

--- a/changelog.d/20260513_172545_moises.gonzalez_add_admin_console.md
+++ b/changelog.d/20260513_172545_moises.gonzalez_add_admin_console.md
@@ -1,4 +1,0 @@
-### Added
-
-- Add support for the Admin Console MFE that was added to the Core MFEs in Ulmo.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tutor-contrib-mfe-extensions"
-version = "21.0.0"
+version = "21.0.1"
 description = "mfe_extensions plugin for Tutor"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tutormfe_extensions/plugin.py
+++ b/tutormfe_extensions/plugin.py
@@ -24,6 +24,14 @@ def validate_mfe_config(mfe_setting_name: str):
 
 @hooks.Actions.CONFIG_LOADED.add()
 def load_config(config: Config):
+    # The tutormfe.plugins.get_mfes function gets cached before we can
+    # register the new list of MFES. This causes discrepancies when using
+    # MFE_*_MFE_APP settings in which some templates that use the `get_mfes`
+    # function will have stale values.
+    #
+    # Manually trigger the PLUGINS_LOADED action clears the cache.
+    hooks.Actions.PLUGIN_LOADED.do("tutormfe_extensions")
+
     @MFE_APPS.add()
     def _manage_mfes_from_config(mfe_list):
         for setting, value in config.items():

--- a/uv.lock
+++ b/uv.lock
@@ -831,7 +831,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/26/d8/3d93bc551ba2e5035
 
 [[package]]
 name = "tutor-contrib-mfe-extensions"
-version = "21.0.0"
+version = "21.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "tutor" },


### PR DESCRIPTION
The [`get_mfes`](https://github.com/overhangio/tutor-mfe/blob/c73f9708878885c7b2e1ddad13d5a90d606ce691/tutormfe/plugin.py#L90-L91) function is getting cached before we register the new list of MFES based on the settings. This causes some templates to render values of MFEs that were supposed to be disabled, for example:

Setting this into the config.yml

```yaml
MFE_AUTHN_MFE_APP: null
```
Will remove the authn MFE from most places, but it will still show up in production.py because the invocation used by the patch [openedx-lms-common-settings](https://github.com/overhangio/tutor-mfe/blob/c73f9708878885c7b2e1ddad13d5a90d606ce691/tutormfe/patches/openedx-lms-common-settings#L8-L9) was cached.