### PR TITLE
docs: delete compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,6 @@ This plugin enhances the default MFE feature set with additional support CDN
 caching and hosting MFEs in paths instead of a dedicated subdomain.
 
 
-## Compatibility Table
-
-| Open edX release | Tutor version     | Tutor MFE Version                    | Plugin release |
-|------------------|-------------------|--------------------------------------|----------------|
-| Nutmeg           | `>=14.0, <15`     | `edunext/tutor-mfe@14.0.2.post1`     | 14.x.x         |
-| Olive            | `>=15.0, <16`     | `edunext/tutor-mfe@15.0.7.post2`     | 15.x.x         |
-| Palm             | `>=16.0, <17`     | `edunext/tutor-mfe@16.1.3.post1`     | 16.x.x         |
-| Quince           | `>=17.0, <18`     | `openedx/tutor-mfe@v17.0.1`          | 17.x.x         |
-| Redwood          | `>=18.0, <19`     | `tutor-mfe>17`                       | 18.x.x         |
-
 ## Installation
 
 ```bash


### PR DESCRIPTION
The plugin follows standard tutor convention for release numbers that makes the table redundant. The table is also prone to getting out of date.